### PR TITLE
conf: from 3.6 onwards mongodb listens on 127.0.0.1

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -15,7 +15,7 @@ logappend=true
 #port = 27017
 
 # Listen to local interface only. Comment out to listen on all interfaces.
-#bind_ip = 127.0.0.1
+bind_ip = {{ ansible_default_ipv4.address }}
 
 # Disables write-ahead journaling
 # nojournal = true


### PR DESCRIPTION
The fact that other package providers (Debian/RedHat/...) were already
binding on 127.0.0.1 was fine, as we mostly used the mongodb package
from their repository. However since 3.6, by default the localhost is
also used for this package, thus making mongodb replication impossible.